### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dnvgl-one.visualstudio.com/456fe6d6-0acc-47eb-8479-90237b03b54c/f3e8e58d-c8c1-4d2e-a3e3-10e614b11091/_apis/work/boardbadge/2b6ae22a-a3fe-444c-9c69-6e721a5b592a)](https://dnvgl-one.visualstudio.com/456fe6d6-0acc-47eb-8479-90237b03b54c/_boards/board/t/f3e8e58d-c8c1-4d2e-a3e3-10e614b11091/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#431056](https://dnvgl-one.visualstudio.com/456fe6d6-0acc-47eb-8479-90237b03b54c/_workitems/edit/431056). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.